### PR TITLE
Fix serialization of extension attributes

### DIFF
--- a/spacy_layout/types.py
+++ b/spacy_layout/types.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 
 from docling_core.types.doc.document import (
     ListItem,
@@ -21,6 +21,9 @@ class Attrs:
     span_data: str
     span_heading: str
     span_group: str
+    doc_layout_internal: str = "_doc_layout"
+    span_layout_internal: str = "_span_layout"
+    span_data_internal: str = "_span_data"
 
 
 @dataclass
@@ -29,12 +32,19 @@ class PageLayout:
     width: float
     height: float
 
+    def to_dict(self) -> dict:
+        return {"page_no": self.page_no, "width": self.width, "height": self.height}
+
 
 @dataclass
 class DocLayout:
     """Document layout features added to Doc object"""
 
     pages: list[PageLayout]
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "DocLayout":
+        return cls(pages=[PageLayout(**page) for page in data["pages"]])
 
 
 @dataclass
@@ -46,3 +56,10 @@ class SpanLayout:
     width: float
     height: float
     page_no: int
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SpanLayout":
+        return cls(**data)
+
+    def to_dict(self) -> dict:
+        return asdict(self)


### PR DESCRIPTION
Fix bug that would prevent serialization of custom extension attributes `DocLayout`, `SpanLayout` and table data as `pd.DataFrame`. Uses internal extension attributes for storing the underlying data that can be serialized, and getter functions to convert the data to custom objects.

Resolves #11.

