### PR TITLE
Allow DoclingDocument as direct input

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ doc = layout("./starcraft.pdf")
 
 | Argument | Type | Description |
 | --- | --- | --- |
-| `source` | `str \| Path \| bytes` | Path of document to process or bytes. |
+| `source` | `str \| Path \| bytes \| DoclingDocument` | Path of document to process, bytes or already created `DoclingDocument`. |
 | **RETURNS** | `Doc` | The processed spaCy `Doc` object. |
 
 #### <kbd>method</kbd> `spaCyLayout.pipe`


### PR DESCRIPTION
Lets `spaCyLayout.__call__` take an already created `DoclingDocument` as direct input to convert to a spaCy `Doc` object.